### PR TITLE
Transform binary errors into miette errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +67,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +115,12 @@ name = "cdrom_crc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79de1ea79db6578ee25a7bcc8fddc58f958e6063aed54f426907d9d9f97895e"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -151,6 +196,7 @@ dependencies = [
  "cdrom",
  "clap",
  "cue",
+ "miette",
 ]
 
 [[package]]
@@ -173,6 +219,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "heck"
@@ -210,10 +262,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.144"
+name = "is_ci"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "libc"
+version = "0.2.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -222,28 +280,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.60"
+name = "owo-colors"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
@@ -260,20 +386,95 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "syn"
-version = "2.0.18"
+name = "supports-color"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "4950e7174bffabe99455511c39707310e7e9b440364a2fcb1cc21521be57b354"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -283,10 +484,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,7 @@ dependencies = [
  "clap",
  "cue",
  "miette",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 clap = { version = "4.3.4", features = ["derive"] }
 cue = "2.0.0"
 miette = { version = "5.6.0", features = ["fancy"] }
+thiserror = "1.0.40"
 
 [dependencies.cdrom]
 path = "cdrom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3.4", features = ["derive"] }
 cue = "2.0.0"
+miette = { version = "5.6.0", features = ["fancy"] }
 
 [dependencies.cdrom]
 path = "cdrom"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,16 @@ use cdrom::Disc;
 use clap::Parser;
 use cue::cd::CD;
 use cue::track::Track;
-use miette::{IntoDiagnostic, Result};
+use miette::{Diagnostic, IntoDiagnostic, Result};
+use thiserror::Error;
+
+#[derive(Error, Debug, Diagnostic)]
+#[error("This tool currently only supports single-file BIN/CUE images.")]
+#[diagnostic(help("Please specify a cuesheet with a single source."))]
+pub struct MultipleFilesError {
+    #[source_code]
+    cue: String,
+}
 
 #[derive(Parser, Debug)]
 #[command(
@@ -47,8 +56,7 @@ fn main() -> Result<()> {
 
     let tracks = cd.tracks();
     if has_multiple_files(tracks) {
-        println!("This tool currently only supports single-file BIN/CUE images.");
-        exit(1);
+        return Err(MultipleFilesError { cue: args.filename })?;
     }
     let fname = cd.tracks().first().unwrap().get_filename();
     let file = root.join(fname);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,11 @@ enum Cue2CCDError {
     },
 
     #[error("A data file specified in the cuesheet is missing.")]
-    #[diagnostic(help("Missing file: {missing_file}"))]
+    #[diagnostic(help("Missing file: {}", missing_file.display()))]
     MissingFileError {
         #[source_code]
         cue: String,
-        missing_file: String,
+        missing_file: std::path::PathBuf,
     },
 
     #[error(transparent)]
@@ -83,7 +83,7 @@ fn work() -> Result<(), Cue2CCDError> {
     if !file.is_file() {
         return Err(Cue2CCDError::MissingFileError {
             cue: args.filename,
-            missing_file: file.to_string_lossy().to_string(),
+            missing_file: file,
         })?;
     }
     let filesize = file.metadata()?.len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,18 +13,11 @@ use thiserror::Error;
 enum Cue2CCDError {
     #[error("This tool currently only supports single-file BIN/CUE images.")]
     #[diagnostic(help("Please specify a cuesheet with a single source."))]
-    MultipleFilesError {
-        #[source_code]
-        cue: String,
-    },
+    MultipleFilesError {},
 
     #[error("A data file specified in the cuesheet is missing.")]
     #[diagnostic(help("Missing file: {}", missing_file.display()))]
-    MissingFileError {
-        #[source_code]
-        cue: String,
-        missing_file: std::path::PathBuf,
-    },
+    MissingFileError { missing_file: std::path::PathBuf },
 
     #[error(transparent)]
     IO(#[from] std::io::Error),
@@ -76,15 +69,12 @@ fn work() -> Result<(), Cue2CCDError> {
 
     let tracks = cd.tracks();
     if has_multiple_files(tracks) {
-        return Err(Cue2CCDError::MultipleFilesError { cue: args.filename })?;
+        return Err(Cue2CCDError::MultipleFilesError {})?;
     }
     let fname = cd.tracks().first().unwrap().get_filename();
     let file = root.join(fname);
     if !file.is_file() {
-        return Err(Cue2CCDError::MissingFileError {
-            cue: args.filename,
-            missing_file: file,
-        })?;
+        return Err(Cue2CCDError::MissingFileError { missing_file: file })?;
     }
     let filesize = file.metadata()?.len();
     // TODO deal with non-2352 byte per sector images (treat as an error?)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::Write;
 use std::path::Path;
 use std::process::exit;
 
@@ -7,6 +7,7 @@ use cdrom::Disc;
 use clap::Parser;
 use cue::cd::CD;
 use cue::track::Track;
+use miette::{IntoDiagnostic, Result};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -36,13 +37,13 @@ fn sector_count(size: u64, sector_size: u64) -> u64 {
     size / sector_size
 }
 
-fn main() -> io::Result<()> {
+fn main() -> Result<()> {
     let args = Args::parse();
 
     let root = Path::new(&args.filename).parent().unwrap();
-    let cue_sheet = std::fs::read_to_string(&args.filename)?;
+    let cue_sheet = std::fs::read_to_string(&args.filename).into_diagnostic()?;
 
-    let cd = CD::parse(cue_sheet)?;
+    let cd = CD::parse(cue_sheet).into_diagnostic()?;
 
     let tracks = cd.tracks();
     if has_multiple_files(tracks) {
@@ -55,22 +56,24 @@ fn main() -> io::Result<()> {
         println!("Cuesheet file {} does not exist", file.to_string_lossy());
         exit(1);
     }
-    let filesize = file.metadata()?.len();
+    let filesize = file.metadata().into_diagnostic()?.len();
     // TODO deal with non-2352 byte per sector images (treat as an error?)
     let sectors = sector_count(filesize, 2352);
     println!("Image is {} sectors long", sectors);
 
     let sub_target = file.with_extension("sub");
-    let mut sub_write = File::create(sub_target)?;
+    let mut sub_write = File::create(sub_target).into_diagnostic()?;
 
     let disc = Disc::from_cuesheet(cd, sectors as i64);
     for sector in disc.sectors() {
-        sub_write.write_all(&sector.generate_subchannel())?;
+        sub_write
+            .write_all(&sector.generate_subchannel())
+            .into_diagnostic()?;
     }
 
     let ccd_target = file.with_extension("ccd");
-    let mut ccd_write = File::create(ccd_target)?;
-    disc.write_ccd(&mut ccd_write)?;
+    let mut ccd_write = File::create(ccd_target).into_diagnostic()?;
+    disc.write_ccd(&mut ccd_write).into_diagnostic()?;
 
     Ok(())
 }


### PR DESCRIPTION
This results in a much nicer error output for the user, for example:

```
Error:   × A data file specified in the cuesheet is missing.
  help: Missing file: testdata/bincue/track1.bin
```