### PR TITLE
Add multi-file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 # uncommitted local test data
 /*.7z
 /real_image
+/realtest
 
 # oranda
 /public


### PR DESCRIPTION
Until now, this has only supported merged disc images and not split Redump-style images. This PR adds support for that. The only real complication is that timestamps in cuesheets for split images are relative, so I needed to start tracking timing information from previous tracks in addition to actually merging the track files.

```
FILE "Track 1.bin" BINARY
  TRACK 01 MODE1/2352
    INDEX 01 00:00:00
FILE "Track 2.bin" BINARY
  TRACK 02 AUDIO
    INDEX 00 00:00:00
    INDEX 01 00:02:00
```

~~I'm comparing against a merged image produced via `chdman`, and this is *almost* right. The diff between the output from a merged image and from a split image only has two differences:~~ This is fixed now.

```diff
--- realtest/merged/disc.ccd	2024-11-24 11:15:43
+++ realtest/split/disc.ccd	2024-11-24 11:52:00
@@ -55,9 +55,9 @@
 ALBA=-150
 Zero=0
 PMin=7
-PSec=52
+PSec=46
 PFrame=58
-PLBA=35308
+PLBA=34858

 [Entry 3]
 Session=1
```

`34858` is the size of the first track image.