### PR TITLE
Bump to cue 3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
         with:
           toolchain: stable
       - uses: swatinem/rust-cache@v2
-      - name: Install dependencies
-        run: sudo apt-get install libcue-dev
       - name: Tests (cdrom)
         run: |
           cd cdrom

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cdrom"
@@ -165,6 +168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,9 +184,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "cue"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8bcf4c6736cccc4eaeb108973e6457cb5c4d6393e29cdf61158cee51c0d4af"
+checksum = "75765c4831c86140893fdd6af61dd461950fcdedea4cf3af2042e1b08cd41355"
 dependencies = [
  "cue-sys",
  "libc",
@@ -182,10 +194,11 @@ dependencies = [
 
 [[package]]
 name = "cue-sys"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb6bf9ed3f73d97b215e5d9c76293095b1fccb1ffd68a8926a8103d11f11440"
+checksum = "1d655a8fb46d3d9550ff44ade93963b2edb770acf0f5ab7d24e29591778d55f8"
 dependencies = [
+ "cmake",
  "libc",
 ]
 
@@ -385,6 +398,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smawk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/mistydemeo/cue2ccd"
 
 [dependencies]
 clap = { version = "4.3.4", features = ["derive"] }
-cue = "2.0.0"
+cue = "3.0.0"
 miette = { version = "5.6.0", features = ["fancy"] }
 thiserror = "1.0.40"
 

--- a/cdrom/Cargo.lock
+++ b/cdrom/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "cc"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cdrom"
 version = "0.1.0"
 dependencies = [
@@ -17,10 +26,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b79de1ea79db6578ee25a7bcc8fddc58f958e6063aed54f426907d9d9f97895e"
 
 [[package]]
-name = "cue"
-version = "2.0.0"
+name = "cmake"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8bcf4c6736cccc4eaeb108973e6457cb5c4d6393e29cdf61158cee51c0d4af"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cue"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75765c4831c86140893fdd6af61dd461950fcdedea4cf3af2042e1b08cd41355"
 dependencies = [
  "cue-sys",
  "libc",
@@ -28,10 +46,11 @@ dependencies = [
 
 [[package]]
 name = "cue-sys"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb6bf9ed3f73d97b215e5d9c76293095b1fccb1ffd68a8926a8103d11f11440"
+checksum = "1d655a8fb46d3d9550ff44ade93963b2edb770acf0f5ab7d24e29591778d55f8"
 dependencies = [
+ "cmake",
  "libc",
 ]
 
@@ -40,3 +59,9 @@ name = "libc"
 version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"

--- a/cdrom/Cargo.toml
+++ b/cdrom/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 cdrom_crc = "0.1.0"
-cue = "2.0.0"
+cue = "3.0.0"


### PR DESCRIPTION
This version brings a static libcue, eliminating the need to provide your own copy.