### PR TITLE
Fix track length calculation

### DIFF
--- a/cdrom/src/lib.rs
+++ b/cdrom/src/lib.rs
@@ -285,7 +285,9 @@ impl Disc {
             // The last track on the disc will have indeterminate length,
             // because the cuesheet doesn't store that; we need to calculate
             // it from the size of the current disc/track image.
-            let length = track.get_length().unwrap_or(current_track_length - start);
+            let length = track
+                .get_length()
+                .unwrap_or(disc_length_so_far + current_track_length - start);
 
             let mut indices = vec![];
             for i in 0..99 {


### PR DESCRIPTION
Track lengths were missing `disc_length_so_far` in the calculation that had been given to track start for split images.

Fixes #15.