### PR TITLE
Implementation of protection commandline flag

### DIFF
--- a/cdrom/src/lib.rs
+++ b/cdrom/src/lib.rs
@@ -437,8 +437,7 @@ impl Sector {
     // http://www.ecma-international.org/publications/standards/Ecma-130.htm
     pub fn generate_subchannel(
         &self,
-        protection: Option<bool>,
-        chosen_protection_type: Option<DiscProtection>,)
+        chosen_protection_type: &Option<DiscProtection>,)
         -> Vec<u8> {
         // The first sector of the disc, and only the first sector,
         // gets an FFed out P sector like a pregap. Every other non-pregap
@@ -456,7 +455,6 @@ impl Sector {
             self.track.number,
             self.index.number,
             self.track.mode,
-            protection,
             chosen_protection_type,
         );
         // The vast majority of real discs write their unused R-W fields as 0s,
@@ -478,9 +476,8 @@ impl Sector {
         track: u8,
         index: u8,
         track_type: TrackMode,
-        protection: Option<bool>,
         chosen_protection_type:
-        Option<DiscProtection>
+        &Option<DiscProtection>
     ) -> Vec<u8> {
         // This channel made up of a sequence of bits; we'll start by
         // zeroing it out, then setting individual bits.
@@ -629,7 +626,7 @@ mod tests {
 
         let mut buf = vec![];
         for sector in disc.sectors() {
-            buf.write_all(&sector.generate_subchannel(None, None)).unwrap();
+            buf.write_all(&sector.generate_subchannel(&None)).unwrap();
         }
 
         let real_sub_path = paths.one_track_ccd.join("basic_image.sub");
@@ -668,7 +665,7 @@ mod tests {
 
         let mut buf = vec![];
         for sector in disc.sectors() {
-            buf.write_all(&sector.generate_subchannel(None, None)).unwrap();
+            buf.write_all(&sector.generate_subchannel(&None)).unwrap();
         }
 
         let real_sub_path = paths.data_plus_audio_ccd.join("disc.sub");

--- a/cdrom/src/lib.rs
+++ b/cdrom/src/lib.rs
@@ -437,7 +437,7 @@ impl Sector {
     // http://www.ecma-international.org/publications/standards/Ecma-130.htm
     pub fn generate_subchannel(
         &self,
-        chosen_protection_type: &Option<DiscProtection>,)
+        _chosen_protection_type: &Option<DiscProtection>,)
         -> Vec<u8> {
         // The first sector of the disc, and only the first sector,
         // gets an FFed out P sector like a pregap. Every other non-pregap
@@ -455,7 +455,7 @@ impl Sector {
             self.track.number,
             self.index.number,
             self.track.mode,
-            chosen_protection_type,
+            _chosen_protection_type,
         );
         // The vast majority of real discs write their unused R-W fields as 0s,
         // but at least one real disc used FFs instead. We'll side with the
@@ -476,7 +476,7 @@ impl Sector {
         track: u8,
         index: u8,
         track_type: TrackMode,
-        chosen_protection_type:
+        _chosen_protection_type:
         &Option<DiscProtection>
     ) -> Vec<u8> {
         // This channel made up of a sequence of bits; we'll start by

--- a/cdrom/src/lib.rs
+++ b/cdrom/src/lib.rs
@@ -435,7 +435,11 @@ impl Sector {
     //
     // More information is in ECMA-130:
     // http://www.ecma-international.org/publications/standards/Ecma-130.htm
-    pub fn generate_subchannel(&self) -> Vec<u8> {
+    pub fn generate_subchannel(
+        &self,
+        protection: Option<bool>,
+        chosen_protection_type: Option<DiscProtection>,)
+        -> Vec<u8> {
         // The first sector of the disc, and only the first sector,
         // gets an FFed out P sector like a pregap. Every other non-pregap
         // sector uses 0s.
@@ -452,6 +456,8 @@ impl Sector {
             self.track.number,
             self.index.number,
             self.track.mode,
+            protection,
+            chosen_protection_type,
         );
         // The vast majority of real discs write their unused R-W fields as 0s,
         // but at least one real disc used FFs instead. We'll side with the
@@ -472,6 +478,9 @@ impl Sector {
         track: u8,
         index: u8,
         track_type: TrackMode,
+        protection: Option<bool>,
+        chosen_protection_type:
+        Option<DiscProtection>
     ) -> Vec<u8> {
         // This channel made up of a sequence of bits; we'll start by
         // zeroing it out, then setting individual bits.
@@ -526,6 +535,7 @@ impl Sector {
         // MIN
         q[3] = bcd(relative_sector_count / 4500);
         // SEC
+        // TODO: Example implementation "If protection is true and protection is [x], else"
         q[4] = bcd((relative_sector_count / 75) % 60);
         // FRAC
         q[5] = bcd(relative_sector_count % 75);
@@ -545,6 +555,17 @@ impl Sector {
 
         q
     }
+}
+
+//TODO: Possible protections, improve descriptions after review
+#[derive(Debug)]
+pub enum DiscProtection {
+    /// Change one second of sector MSFs
+    DiscGuard,
+    /// Subchannel-error-based PC protection
+    SecuROM,
+    /// Subchannel-error-based PS1 protection
+    LibCrypt,
 }
 
 // For more detail, see section 22.3.4.2 of ECMA-130.
@@ -608,7 +629,7 @@ mod tests {
 
         let mut buf = vec![];
         for sector in disc.sectors() {
-            buf.write_all(&sector.generate_subchannel()).unwrap();
+            buf.write_all(&sector.generate_subchannel(None, None)).unwrap();
         }
 
         let real_sub_path = paths.one_track_ccd.join("basic_image.sub");
@@ -647,7 +668,7 @@ mod tests {
 
         let mut buf = vec![];
         for sector in disc.sectors() {
-            buf.write_all(&sector.generate_subchannel()).unwrap();
+            buf.write_all(&sector.generate_subchannel(None, None)).unwrap();
         }
 
         let real_sub_path = paths.data_plus_audio_ccd.join("disc.sub");

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,7 @@ fn work() -> Result<(), Cue2CCDError> {
     let disc = Disc::from_cuesheet(cd, root);
     for sector in disc.sectors() {
         sub_write
-            .write_all(&sector.generate_subchannel(&chosen_protection_type))
-            .expect("This should never be modified");
+            .write_all(&sector.generate_subchannel(&chosen_protection_type))?;
     }
 
     let ccd_target = output_stem.with_extension("ccd");


### PR DESCRIPTION
Before I implement any specific protection's processing, I want to get the base functionality for taking protection via an optional commandline flag and allowing it to change functionality within generate_q_subchannel if present. I'm aware that this has major issues at the moment, but before I go further, I just wanted to make sure this general approach was ok, or if you would want it a different way. Please let me know what you think of my approach when you have time, if you feel it is desired and within scope of your project.