### PR TITLE
fix: "syntax error" message when parsing cue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,9 @@ fn work() -> Result<(), Cue2CCDError> {
     let output_stem = output_path.join(basename);
 
     let cue_sheet = std::fs::read_to_string(&args.filename)?;
+    // Trim trailing newlines to work around a libcue bug:
+    // https://github.com/lipnitsk/libcue/issues/52
+    let cue_sheet = cue_sheet.trim_end_matches(['\r', '\n']).to_owned();
 
     let cd = CD::parse(cue_sheet)?;
 


### PR DESCRIPTION
This is caused by a quirk in libcue which only happens if the cuesheet ends with a trailing newline. Trimming all trailing newlines works to silence ths.