### PR TITLE
ci: use ubuntu-22.04 for all linux builds

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -19,8 +19,10 @@ publish-jobs = ["homebrew"]
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Temporary, to let us upgrade the Ubuntu version
-allow-dirty = ["ci"]
 
 [dist.dependencies.chocolatey]
 winflexbison = '*'
+
+[dist.github-custom-runners]
+global = "ubuntu-22.04"
+x86_64-unknown-linux-gnu = "ubuntu-22.04"


### PR DESCRIPTION
I need to make sure we use ubuntu-22.04 for the actual build too. I'd forgotten I can set the `global` runner to that and avoid having to do `allow-dirty`, so went ahead and did that.