### PR TITLE
fix: lifetime warning from recent rust

### DIFF
--- a/cdrom/src/lib.rs
+++ b/cdrom/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Disc {
 }
 
 impl Disc {
-    pub fn sectors(&self) -> SectorIterator {
+    pub fn sectors(&self) -> SectorIterator<'_> {
         SectorIterator {
             current: 0,
             disc: self,


### PR DESCRIPTION
Looks like this is new from Rust 1.89: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint

```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> cdrom/src/lib.rs:31:20
   |
31 |     pub fn sectors(&self) -> SectorIterator {
   |                    ^^^^^     ^^^^^^^^^^^^^^ the same lifetime is hidden here
   |                    |
   |                    the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
```